### PR TITLE
overwrite overwritten font-size with browser initial value

### DIFF
--- a/custom_liferay_overwrite.css
+++ b/custom_liferay_overwrite.css
@@ -1,3 +1,12 @@
+/* use the standard value of 16px for rem computation*/
+:root {
+  font-size: initial;
+}
+.aui body {
+  font-size: initial;
+}
+
+
 /* Makes Navigation bar go over entire page width 
 and Removes Side margins from Liferay Homepage */
 #wrapper {


### PR DESCRIPTION
The navigation bar and other elements look to small. The cause of this is a styling decision in the liferay theme which sets the root `font-size` to `14px`. All calculations using `rem` are thereby off. The default value for the `font-size` should be provided by the client and usually amounts to `16px`. 

The value of `14px` is overwritten with this PR and set to `initial`.